### PR TITLE
Pin version in sdists

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ pip-wheel-metadata
 # due to using tox and pytest
 .tox
 .cache
+/dist/
+/pip-wheel-metadata/
+/.venv/

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
         ],
     },
     use_calver=True,
-    setup_requires=['calver-pinning'],
+    setup_requires=["calver-pinning"],
     # XXX: What's the minimum version of setuptools?
-    install_requires=['setuptools'],
+    install_requires=["setuptools"],
 )

--- a/setup.py
+++ b/setup.py
@@ -31,4 +31,7 @@ setup(
         ],
     },
     use_calver=True,
+    setup_requires=['calver-pinning'],
+    # XXX: What's the minimum version of setuptools?
+    install_requires=['setuptools'],
 )

--- a/src/calver/commands.py
+++ b/src/calver/commands.py
@@ -7,7 +7,7 @@ import setuptools.command.sdist
 class sdist(setuptools.command.sdist.sdist):
     def make_release_tree(self, base_dir, files):
         super().make_release_tree(base_dir, files)
-        verfile = os.path.join(base_dir, '.calver-version')
+        verfile = os.path.join(base_dir, ".calver-version")
         log.info("Writing version file {}".format(verfile))
-        with open(verfile, 'wt') as f:
+        with open(verfile, "wt") as f:
             f.write(self.distribution.metadata.version)

--- a/src/calver/commands.py
+++ b/src/calver/commands.py
@@ -1,5 +1,5 @@
-from distutils import log
 import os
+from distutils import log
 
 import setuptools.command.sdist
 

--- a/src/calver/commands.py
+++ b/src/calver/commands.py
@@ -6,7 +6,6 @@ import setuptools.command.sdist
 
 class sdist(setuptools.command.sdist.sdist):
     def make_release_tree(self, base_dir, files):
-        print(f"{self=} {base_dir=} {files=}")
         super().make_release_tree(base_dir, files)
         verfile = os.path.join(base_dir, '.calver-version')
         log.info("Writing version file {}".format(verfile))

--- a/src/calver/commands.py
+++ b/src/calver/commands.py
@@ -1,0 +1,14 @@
+from distutils import log
+import os
+
+import setuptools.command.sdist
+
+
+class sdist(setuptools.command.sdist.sdist):
+    def make_release_tree(self, base_dir, files):
+        print(f"{self=} {base_dir=} {files=}")
+        super().make_release_tree(base_dir, files)
+        verfile = os.path.join(base_dir, '.calver-version')
+        log.info("Writing version file {}".format(verfile))
+        with open(verfile, 'wt') as f:
+            f.write(self.distribution.metadata.version)

--- a/src/calver/integration.py
+++ b/src/calver/integration.py
@@ -28,8 +28,10 @@ def version(dist, keyword, value):
     else:
         return
 
-    assert 'sdist' not in dist.cmdclass, "FIXME: Handle an already-overridden sdist"
-    dist.cmdclass['sdist'] = commands.sdist
+    if 'sdist' not in dist.cmdclass:
+        dist.cmdclass['sdist'] = commands.sdist
+    else:
+        assert dist.cmdclass['sdist'] is commands.sdist, "FIXME: Handle an already-overridden sdist"
 
     try:
         dist.metadata.version = read_version_file(dist)

--- a/src/calver/integration.py
+++ b/src/calver/integration.py
@@ -5,14 +5,14 @@ from . import commands
 
 DEFAULT_FORMAT = "%Y.%m.%d"
 
-VERSION_FILE = '.calver-version'
+VERSION_FILE = ".calver-version"
 
 
 def read_version_file(dist):
     # FIXME: Can we get the project directory?
     src = dist.src_root or os.getcwd()
     fn = os.path.join(src, VERSION_FILE)
-    with open(fn, 'rt') as f:
+    with open(fn, "rt") as f:
         return f.read()
 
 
@@ -20,7 +20,7 @@ def version(dist, keyword, value):
     if not value:
         return
     elif value is True:
-        generate_version = lambda: datetime.datetime.now().strftime(DEFAULT_FORMAT)  # noqa: E501
+        generate_version = lambda: datetime.datetime.now().strftime(DEFAULT_FORMAT)
     elif isinstance(value, str):
         generate_version = lambda: datetime.datetime.now().strftime(value)
     elif getattr(value, "__call__", None):
@@ -28,10 +28,12 @@ def version(dist, keyword, value):
     else:
         return
 
-    if 'sdist' not in dist.cmdclass:
-        dist.cmdclass['sdist'] = commands.sdist
+    if "sdist" not in dist.cmdclass:
+        dist.cmdclass["sdist"] = commands.sdist
     else:
-        assert dist.cmdclass['sdist'] is commands.sdist, "FIXME: Handle an already-overridden sdist"
+        assert (
+            dist.cmdclass["sdist"] is commands.sdist
+        ), "FIXME: Handle an already-overridden sdist"
 
     try:
         dist.metadata.version = read_version_file(dist)

--- a/src/calver/integration.py
+++ b/src/calver/integration.py
@@ -1,5 +1,7 @@
 import datetime
-import pathlib
+import os
+
+from . import commands
 
 DEFAULT_FORMAT = "%Y.%m.%d"
 
@@ -8,8 +10,10 @@ VERSION_FILE = '.calver-version'
 
 def read_version_file(dist):
     # FIXME: Can we get the project directory?
-    fn = pathlib.Path.cwd() / VERSION_FILE
-    return fn.read_text()
+    src = dist.src_root or os.getcwd()
+    fn = os.path.join(src, VERSION_FILE)
+    with open(fn, 'rt') as f:
+        return f.read()
 
 
 def version(dist, keyword, value):
@@ -23,6 +27,9 @@ def version(dist, keyword, value):
         generate_version = value
     else:
         return
+
+    assert 'sdist' not in dist.cmdclass, "FIXME: Handle an already-overridden sdist"
+    dist.cmdclass['sdist'] = commands.sdist
 
     try:
         dist.metadata.version = read_version_file(dist)

--- a/src/calver/integration.py
+++ b/src/calver/integration.py
@@ -1,13 +1,22 @@
 import datetime
+import pathlib
 
 DEFAULT_FORMAT = "%Y.%m.%d"
+
+VERSION_FILE = '.calver-version'
+
+
+def read_version_file(dist):
+    # FIXME: Can we get the project directory?
+    fn = pathlib.Path.cwd() / VERSION_FILE
+    return fn.read_text()
 
 
 def version(dist, keyword, value):
     if not value:
         return
     elif value is True:
-        generate_version = lambda: datetime.datetime.now().strftime(DEFAULT_FORMAT)
+        generate_version = lambda: datetime.datetime.now().strftime(DEFAULT_FORMAT)  # noqa: E501
     elif isinstance(value, str):
         generate_version = lambda: datetime.datetime.now().strftime(value)
     elif getattr(value, "__call__", None):
@@ -15,4 +24,7 @@ def version(dist, keyword, value):
     else:
         return
 
-    dist.metadata.version = generate_version()
+    try:
+        dist.metadata.version = read_version_file(dist)
+    except FileNotFoundError:
+        dist.metadata.version = generate_version()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,9 +1,9 @@
 import datetime
 
-import pytest
 import pretend
+import pytest
 
-from calver.integration import version, DEFAULT_FORMAT
+from calver.integration import DEFAULT_FORMAT, version
 
 
 @pytest.fixture

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -13,7 +13,11 @@ def original_version():
 
 @pytest.fixture
 def dist(original_version):
-    return pretend.stub(metadata=pretend.stub(version=original_version))
+    return pretend.stub(
+        metadata=pretend.stub(version=original_version),
+        cmdclass={},
+        src_root=None,
+    )
 
 
 @pytest.fixture
@@ -45,9 +49,16 @@ def test_version_str(dist, keyword):
 
 
 def test_version_callable(dist, keyword):
-    version = pretend.stub()
-    value = lambda: version
+    ver = pretend.stub()
+    value = lambda: ver
 
     version(dist, keyword, value) is None
 
-    assert dist.metadata.version == version
+    assert dist.metadata.version == ver
+
+
+def test_run_twice(dist, keyword):
+    value = True
+
+    version(dist, keyword, value)
+    version(dist, keyword, value)


### PR DESCRIPTION
Per the discussion in #2, sdists cause problems with this kind of calver handling.

This adds the ability to pin the version, so it'll use that instead of the current date/time, and then also does the pinning during `sdist` packaging.