### PR TITLE
Remove redundant wheel dep from pyproject.toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ it as one of the build requirements:
 `pyproject.toml`:
 ```toml
 [build-system]
-requires = ["setuptools>=42", "wheel", "calver"]
+requires = ["setuptools>=42", "calver"]
 ```
 
 To enable generating the version automatically based on the date, add the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools", "wheel", "calver"]
+requires = ["setuptools", "calver"]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Remove the redundant `wheel` dependency, as it is added by the backend
automatically.  Listing it explicitly in the documentation was
a historical mistake and has been fixed since, see:
https://github.com/pypa/setuptools/commit/f7d30a9529378cf69054b5176249e5457aaf640a