### PR TITLE
Support Python 3.11, test 3.12-dev, drop EOL 3.5-3.6

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,9 +4,9 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Setup Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
     - name: Install tox
       run: python -m pip install tox
     - name: Lint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,5 +1,9 @@
 name: Lint
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
+
+env:
+  FORCE_COLOR: 1
+
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -7,6 +11,8 @@ jobs:
     - uses: actions/checkout@v3
     - name: Setup Python
       uses: actions/setup-python@v4
+      with:
+        python-version: "3.x"
     - name: Install tox
       run: python -m pip install tox
     - name: Lint

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: '3.x'
     - name: Install dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: [3.6, 3.7, 3.8, 3.9]
+        python: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12-dev"]
     runs-on: ubuntu-latest
     steps:
     - name: Checkout

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,8 +1,13 @@
 name: Tests
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
+
+env:
+  FORCE_COLOR: 1
+
 jobs:
   test:
     strategy:
+      fail-fast: false
       matrix:
         python: [3.6, 3.7, 3.8, 3.9]
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,9 +8,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Use Python ${{ matrix.python }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python }}
     - name: Install tox

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ setup(
 
 You can test that it is working with:
 
-```
+```console
 $ python setup.py --version
 2020.6.16
 ```
@@ -41,7 +41,7 @@ $ python setup.py --version
 By default, when setting `use_calver=True`, it uses the following to generate
 the version string:
 
-```
+```pycon
 >>> import datetime
 >>> datetime.datetime.now().strftime("%Y.%m.%d")
 2020.6.16

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     keywords="calver",
     package_dir={"": "src"},
     packages=find_packages(where="src"),
-    python_requires=">=3.5",
+    python_requires=">=3.7",
     entry_points={
         "distutils.setup_keywords": [
             "use_calver = calver.integration:version",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{35,36,37,38,39},lint
+envlist = py{37,38,39,310,311,312},lint
 minversion = 3.3.0
 isolated_build = true
 


### PR DESCRIPTION
Plus some config and README formatting updates.