### PR TITLE
test: Delete SOURCE_DATE_EPOCH envvar if already present for robustness

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
+recursive-include tests *.py
 include pyproject.toml
 include tox.ini
 include *.md

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,39 @@
+import os
+
+import pretend
+import pytest
+
+import calver.integration
+
+
+@pytest.fixture
+def original_version():
+    return pretend.stub()
+
+
+@pytest.fixture
+def dist(original_version):
+    return pretend.stub(metadata=pretend.stub(version=original_version))
+
+
+@pytest.fixture
+def keyword():
+    return pretend.stub()
+
+
+@pytest.fixture
+def ignore_pkginfo(monkeypatch):
+    # Ensure that the test doesn't unintently prefer to read from a PKG_INFO
+    # that might exist in the source directory, e.g. when testing a sdist
+    # https://github.com/di/calver/issues/20
+    monkeypatch.setattr(
+        calver.integration, "get_pkginfo_contents", pretend.raiser(FileNotFoundError)
+    )
+
+
+@pytest.fixture
+def source_date_epoch(monkeypatch):
+    _source_date_epoch = 1234567890
+    monkeypatch.setenv("SOURCE_DATE_EPOCH", str(_source_date_epoch))
+    yield _source_date_epoch
+    monkeypatch.delenv("SOURCE_DATE_EPOCH")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,7 @@ def pytest_configure(config):
     if "SOURCE_DATE_EPOCH" in os.environ:
         del os.environ["SOURCE_DATE_EPOCH"]
 
+
 @pytest.fixture
 def original_version():
     return pretend.stub()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,12 @@ import pytest
 import calver.integration
 
 
+# Clean environment variable SOURCE_DATE_EPOCH if it's already present, e.g.
+# set up by packaging tool, since it may mess up logic of our testsuite.
+def pytest_configure(config):
+    if "SOURCE_DATE_EPOCH" in os.environ:
+        del os.environ["SOURCE_DATE_EPOCH"]
+
 @pytest.fixture
 def original_version():
     return pretend.stub()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,42 +1,10 @@
 import datetime
+import os
 
 import pretend
 import pytest
 
 import calver.integration
-
-
-@pytest.fixture
-def original_version():
-    return pretend.stub()
-
-
-@pytest.fixture
-def dist(original_version):
-    return pretend.stub(metadata=pretend.stub(version=original_version))
-
-
-@pytest.fixture
-def keyword():
-    return pretend.stub()
-
-
-@pytest.fixture
-def ignore_pkginfo(monkeypatch):
-    # Ensure that the test doesn't unintently prefer to read from a PKG_INFO
-    # that might exist in the source directory, e.g. when testing a sdist
-    # https://github.com/di/calver/issues/20
-    monkeypatch.setattr(
-        calver.integration, "get_pkginfo_contents", pretend.raiser(FileNotFoundError)
-    )
-
-
-@pytest.fixture
-def source_date_epoch(monkeypatch):
-    _source_date_epoch = 1234567890
-    monkeypatch.setenv("SOURCE_DATE_EPOCH", str(_source_date_epoch))
-    yield _source_date_epoch
-    monkeypatch.delenv("SOURCE_DATE_EPOCH")
 
 
 @pytest.mark.parametrize("value", [None, False, ""])


### PR DESCRIPTION
Since commit e1f9f3aaa5fc ("Support SOURCE_DATE_EPOCH for reproducible builds (#15)"), calver may pretend current date is value of environment variable "SOURCE_DATE_EPOCH". But when running testsuite in packaging scenarios, the packaging tool, for example, makepkg, may set up its own SOURCE_DATE_EPOCH and break our expected code path to train.

Let's delete the variable from os.environ if it's already present when starting the testsuite, improving its robustness.